### PR TITLE
List categories on the homepage

### DIFF
--- a/articles/pt-BR/primeiros-passos/ola-mundo.md
+++ b/articles/pt-BR/primeiros-passos/ola-mundo.md
@@ -1,0 +1,8 @@
+---
+title: 'Olá Mundo'
+description: 'Lorem ipsum dolor sit amet consectetuer adispiscing elit'
+order: 1
+updatedAt: '2020-10-03'
+---
+
+Lorem **ipsum dolor** sit amet consectetuer adispiscing elit.

--- a/components/lists/ArticlesList.tsx
+++ b/components/lists/ArticlesList.tsx
@@ -1,8 +1,8 @@
-import Link from 'next/link';
 import React from 'react';
 import styled from 'styled-components';
 
 import { CategoryArticleType } from '../../utils/datasource';
+import ListItem from './ListItem';
 
 interface Props {
   articles: CategoryArticleType[];
@@ -13,14 +13,13 @@ export default function ArticlesList({ articles, locale }: Props) {
   return (
     <Container>
       {articles.map((article) => (
-        <Item key={article.slug}>
-          <Link href={article.url} locale={locale}>
-            <ItemLink>
-              <ItemLabel>{article.meta.title}</ItemLabel>
-              <ItemDescription>{article.meta.description}</ItemDescription>
-            </ItemLink>
-          </Link>
-        </Item>
+        <ListItem
+          key={article.slug}
+          title={article.meta.title}
+          description={article.meta.title}
+          path={article.url}
+          locale={locale}
+        />
       ))}
     </Container>
   );
@@ -28,19 +27,4 @@ export default function ArticlesList({ articles, locale }: Props) {
 
 const Container = styled.ul.attrs({
   className: 'space-y-4',
-})``;
-
-const Item = styled.li``;
-
-const ItemLink = styled.a.attrs({
-  className:
-    'flex flex-col cursor-pointer border border-gray-50 bg-gray-50 rounded-xl p-6 space-y-1 hover:bg-white hover:border-gray-200',
-})``;
-
-const ItemLabel = styled.p.attrs({
-  className: 'font-semibold text-lg text-primary-500',
-})``;
-
-const ItemDescription = styled.p.attrs({
-  className: 'text-gray-500',
 })``;

--- a/components/lists/CategoriesList.tsx
+++ b/components/lists/CategoriesList.tsx
@@ -1,0 +1,41 @@
+import useTranslation from 'next-translate/useTranslation';
+import React from 'react';
+import styled from 'styled-components';
+
+import { CategoryListItemType } from '../../utils/datasource';
+import ListItem from './ListItem';
+
+interface Props {
+  categories: CategoryListItemType[];
+  locale: string;
+}
+
+export default function CategoriesList({ categories, locale }: Props) {
+  const { t } = useTranslation('categories');
+
+  const sortedCategories = categories.sort((a, b) => {
+    console.log(t(`${a.category}.title`));
+    console.log(t(`${a.category}.order`));
+    console.log(t(`${b.category}.order`));
+
+    return Number(t(`${a.category}.order`)) - Number(t(`${b.category}.order`));
+  });
+
+  return (
+    <Container>
+      {sortedCategories.map(({ category }) => (
+        <ListItem
+          key={category}
+          title={t(`${category}.title`)}
+          description={t(`${category}.description`)}
+          path={category}
+          locale={locale}
+        />
+      ))}
+    </Container>
+  );
+}
+
+const Container = styled.ul.attrs({
+  className: 'grid gap-4 md:grid-cols-2',
+})``;

--- a/components/lists/ListItem.tsx
+++ b/components/lists/ListItem.tsx
@@ -1,0 +1,33 @@
+import Link from 'next/link';
+import React from 'react';
+import styled from 'styled-components';
+
+interface Props {
+  title: string;
+  description: string;
+  path: string;
+  locale: string;
+}
+
+export default function ListItem({ title, description, path, locale }: Props) {
+  return (
+    <Item key={path}>
+      <Link href={path} locale={locale}>
+        <ItemLink>
+          <ItemLabel>{title}</ItemLabel>
+          <ItemDescription>{description}</ItemDescription>
+        </ItemLink>
+      </Link>
+    </Item>
+  );
+}
+
+const Item = styled.li``;
+
+const ItemLink = styled.a.attrs({
+  className:
+    'flex flex-col cursor-pointer border border-gray-50 bg-gray-50 rounded-xl p-6 space-y-1 hover:bg-white hover:border-gray-200',
+})``;
+
+const ItemLabel = styled.p.attrs({ className: 'font-semibold text-lg text-primary-500' })``;
+const ItemDescription = styled.p.attrs({ className: 'text-gray-500' })``;

--- a/i18n.js
+++ b/i18n.js
@@ -1,5 +1,5 @@
 module.exports = {
-  locales: ['en'],
+  locales: ['en', 'pt-BR'],
   defaultLocale: 'en',
   pages: {
     '*': ['common', 'categories'],

--- a/locales/en/categories.json
+++ b/locales/en/categories.json
@@ -1,6 +1,7 @@
 {
   "getting-started": {
     "title": "Getting Started",
-    "description": "Lorem ipsum dolor sit amet."
+    "description": "Lorem ipsum dolor sit amet.",
+    "order": "1"
   }
 }

--- a/locales/pt-BR/categories.json
+++ b/locales/pt-BR/categories.json
@@ -1,6 +1,7 @@
 {
   "primeiros-passos": {
     "title": "Primeiros Passos",
-    "description": "Lorem ipsum dolor sit amet."
+    "description": "Lorem ipsum dolor sit amet.",
+    "order": "1"
   }
 }

--- a/locales/pt-BR/categories.json
+++ b/locales/pt-BR/categories.json
@@ -1,0 +1,6 @@
+{
+  "primeiros-passos": {
+    "title": "Primeiros Passos",
+    "description": "Lorem ipsum dolor sit amet."
+  }
+}

--- a/locales/pt-BR/common.json
+++ b/locales/pt-BR/common.json
@@ -1,0 +1,9 @@
+{
+  "pageTitle": "{{ brand }} Central de Ajuda",
+  "homePageTitle": "Central de Ajuda",
+  "header": {
+    "backTo": "Voltar para {{ brand }}",
+    "contactUs": "Entre em contato",
+    "title": "Como podemos ajudar?"
+  }
+}

--- a/pages/[category]/[slug].tsx
+++ b/pages/[category]/[slug].tsx
@@ -43,6 +43,6 @@ export async function getStaticProps({ params, locale }: ContextParams) {
 export async function getStaticPaths() {
   return {
     fallback: false,
-    paths: getArticlesList().map((article) => ({ params: article })),
+    paths: getArticlesList().map((article) => ({ params: article, locale: article.locale })),
   };
 }

--- a/pages/[category]/index.tsx
+++ b/pages/[category]/index.tsx
@@ -73,6 +73,6 @@ export async function getStaticProps({ params, locale }: ContextParams) {
 export async function getStaticPaths() {
   return {
     fallback: false,
-    paths: getCategoriesList().map((category) => ({ params: category })),
+    paths: getCategoriesList().map((category) => ({ params: category, locale: category.locale })),
   };
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,11 +1,30 @@
+import { GetStaticPropsContext } from 'next';
 import React from 'react';
 
 import Screen from '../components/containers/Screen';
+import ScreenContent from '../components/containers/ScreenContent';
+import CategoriesList from '../components/lists/CategoriesList';
+import { CategoryListItemType, getCategoriesList } from '../utils/datasource';
 
-export default function Home() {
+interface Props {
+  categories: CategoryListItemType[];
+  locale: string;
+}
+
+export default function HomePage({ categories, locale }: Props) {
   return (
     <Screen>
-      <h1>Hello, there! 👋</h1>
+      <ScreenContent>
+        <CategoriesList categories={categories} locale={locale} />
+      </ScreenContent>
     </Screen>
   );
+}
+
+export async function getStaticProps({ locale }: GetStaticPropsContext) {
+  const categories = getCategoriesList(locale);
+
+  return {
+    props: { categories, locale },
+  };
 }

--- a/utils/datasource.ts
+++ b/utils/datasource.ts
@@ -78,7 +78,7 @@ export async function getCategoryArticles(locale: string, category: string) {
   return articles.sort((a, b) => a.meta.order - b.meta.order);
 }
 
-export function getCategoriesList() {
+export function getCategoriesList(locale?: string) {
   const categories = [];
 
   fs.readdirSync(articlesDirectory).forEach((locale) => {
@@ -86,6 +86,10 @@ export function getCategoriesList() {
       categories.push({ locale, category });
     });
   });
+
+  if (locale) {
+    return categories.filter((category) => category.locale === locale);
+  }
 
   return categories;
 }


### PR DESCRIPTION
Categories are now being listed on the homepage. A filter by location is applied. Entries are sorted by an `order` attribute available as part of the categories' translation files. Resolves #13.